### PR TITLE
feat: enhance Swagger with dynamic config and server-specific endpoints

### DIFF
--- a/cmd/cmd_main/commands/constants.go
+++ b/cmd/cmd_main/commands/constants.go
@@ -486,6 +486,18 @@ import (
 type App struct {}
 
 // Init - initialize the app
+// @title {{.ProjectName}} API
+// @version 1.0
+// @description This is the {{.ProjectName}} API server built with Gonyx framework
+// @termsOfService http://swagger.io/terms/
+// @contact.name API Support
+// @contact.url http://www.swagger.io/support
+// @contact.email support@swagger.io
+// @license.name Apache 2.0
+// @license.url http://www.apache.org/licenses/LICENSE-2.0.html
+// @host localhost:3000
+// @BasePath /
+// @schemes http https
 func (app *App) Init() {
     engine.RegisterRestfulController(&SampleController{})
 

--- a/cmd/cmd_main/commands/templates/app.app.gotmpl
+++ b/cmd/cmd_main/commands/templates/app.app.gotmpl
@@ -21,6 +21,18 @@ import (
 type App struct {}
 
 // Init - initialize the app
+// @title {{.ProjectName}} API
+// @version 1.0
+// @description This is the {{.ProjectName}} API server built with Gonyx framework
+// @termsOfService http://swagger.io/terms/
+// @contact.name API Support
+// @contact.url http://www.swagger.io/support
+// @contact.email support@swagger.io
+// @license.name Apache 2.0
+// @license.url http://www.apache.org/licenses/LICENSE-2.0.html
+// @host localhost:3000
+// @BasePath /
+// @schemes http https
 func (app *App) Init() {
     engine.RegisterRestfulController(&SampleController{})
 


### PR DESCRIPTION
- Use GinServer instance name for swagger endpoints (/{serverName}/swagger.json)
- Dynamically update swagger title, version, and description from base config
- Filter API paths based on server's supported versions
- Update swagger UI URL to use server-specific JSON endpoint
- Add isPathSupportedByServer() method for version-based API filtering
- Replace static swagger.json loading with dynamic server-aware processing

Swagger documentation is now truly server-specific, showing only APIs supported by each server instance and using config-driven metadata.