### PR TITLE
fix: improve swagger path validation and config retrieval

### DIFF
--- a/internal/config/manager.go
+++ b/internal/config/manager.go
@@ -3,12 +3,13 @@ package config
 // Imports needed list
 import (
 	"fmt"
-	"github.com/fsnotify/fsnotify"
-	"github.com/spf13/viper"
 	"log"
 	"os"
 	"sync"
 	"time"
+
+	"github.com/fsnotify/fsnotify"
+	"github.com/spf13/viper"
 )
 
 // Mark: manager
@@ -186,6 +187,11 @@ func (p *manager) GetConfigWrapper(category string) (*ViperWrapper, error) {
 // GetName - returns service instance name based on config
 func (p *manager) GetName() string {
 	return viper.GetString("name")
+}
+
+// GetVersion - returns service instance name based on config
+func (p *manager) GetVersion() string {
+	return viper.GetString("version")
 }
 
 // GetOperationType - returns operation type which could be `dev`, `prod`

--- a/internal/logger/zhycan_wrapper.go
+++ b/internal/logger/zhycan_wrapper.go
@@ -4,14 +4,15 @@ package logger
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/Blocktunium/gonyx/internal/config"
-	"github.com/Blocktunium/gonyx/internal/logger/types"
-	"github.com/Blocktunium/gonyx/internal/utils"
-	"gorm.io/gorm"
 	"log"
 	"os"
 	"sync"
 	"time"
+
+	"github.com/Blocktunium/gonyx/internal/config"
+	"github.com/Blocktunium/gonyx/internal/logger/types"
+	"github.com/Blocktunium/gonyx/internal/utils"
+	"gorm.io/gorm"
 
 	"github.com/Blocktunium/gonyx/internal/logger/helpers"
 )
@@ -110,7 +111,7 @@ func (l *LogMeWrapper) Constructor(name string) error {
 								if dbType == "sql" {
 									r.dbType = dbType
 
-									insDb, err := helpers.GetSqlDbInstance("server1")
+									insDb, err := helpers.GetSqlDbInstance(useDbName)
 									if err != nil {
 										log.Printf("Cannot Db instance: %v for logger", item)
 									} else {


### PR DESCRIPTION
- Use config.GetManager().GetName() and GetVersion() for cleaner config access
- Fix isPathSupportedByServer to validate against actual registered routes
- Ensure swagger only includes routes that exist in the gin server instance
- Remove fallback logic and simplify app name/version retrieval

The swagger documentation now accurately reflects only the routes actually registered in each server instance.